### PR TITLE
Seek to file offset crash fix

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -198,7 +198,7 @@ RCT_EXPORT_METHOD(write:(NSString *)filepath
     NSFileHandle *fH = [NSFileHandle fileHandleForUpdatingAtPath:filepath];
 
     if (position >= 0) {
-      [fH seekToFileOffset:position];
+      [fH seekToFileOffset: (UInt64)position];
     } else {
       [fH seekToEndOfFile];
     }
@@ -294,8 +294,8 @@ RCT_EXPORT_METHOD(readFile:(NSString *)filepath
 }
 
 RCT_EXPORT_METHOD(read:(NSString *)filepath
-                  length: (NSInteger *)length
-                  position: (NSInteger *)position
+                  length: (NSInteger)length
+                  position: (NSInteger)position
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -324,7 +324,7 @@ RCT_EXPORT_METHOD(read:(NSString *)filepath
     }
 
     // Seek to the position if there is one.
-    [file seekToFileOffset: (int)position];
+    [file seekToFileOffset: (UInt64)position];
 
     NSData *content;
     if ((int)length > 0) {

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -175,7 +175,7 @@ RCT_EXPORT_METHOD(appendFile:(NSString *)filepath
 
 RCT_EXPORT_METHOD(write:(NSString *)filepath
                   contents:(NSString *)base64Content
-                  position:(NSInteger)position
+                  position:(NSNumber *)position
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -197,8 +197,8 @@ RCT_EXPORT_METHOD(write:(NSString *)filepath
   @try {
     NSFileHandle *fH = [NSFileHandle fileHandleForUpdatingAtPath:filepath];
 
-    if (position >= 0) {
-      [fH seekToFileOffset: (UInt64)position];
+    if ([position unsignedLongLongValue] >= 0) {
+      [fH seekToFileOffset: [position unsignedLongLongValue]];
     } else {
       [fH seekToEndOfFile];
     }
@@ -294,8 +294,8 @@ RCT_EXPORT_METHOD(readFile:(NSString *)filepath
 }
 
 RCT_EXPORT_METHOD(read:(NSString *)filepath
-                  length: (NSInteger)length
-                  position: (NSInteger)position
+                  length: (NSNumber *)length
+                  position: (NSNumber *)position
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -324,11 +324,11 @@ RCT_EXPORT_METHOD(read:(NSString *)filepath
     }
 
     // Seek to the position if there is one.
-    [file seekToFileOffset: (UInt64)position];
+    [file seekToFileOffset: [position unsignedLongLongValue]];
 
     NSData *content;
-    if ((int)length > 0) {
-        content = [file readDataOfLength: (int)length];
+    if ([length intValue] > 0) {
+        content = [file readDataOfLength: [length intValue]];
     } else {
         content = [file readDataToEndOfFile];
     }

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -186,7 +186,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void write(String filepath, String base64Content, int position, Promise promise) {
+  public void write(String filepath, String base64Content, long position, Promise promise) {
     try {
       byte[] bytes = Base64.decode(base64Content, Base64.DEFAULT);
 
@@ -234,7 +234,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void read(String filepath, int length, int position, Promise promise) {
+  public void read(String filepath, int length, long position, Promise promise) {
     try {
       InputStream inputStream = getInputStream(filepath);
       byte[] buffer = new byte[length];

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -186,7 +186,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void write(String filepath, String base64Content, long position, Promise promise) {
+  public void write(String filepath, String base64Content, double position, Promise promise) {
     try {
       byte[] bytes = Base64.decode(base64Content, Base64.DEFAULT);
 
@@ -196,7 +196,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
         outputStream.close();
       } else {
         RandomAccessFile file = new RandomAccessFile(filepath, "rw");
-        file.seek(position);
+        file.seek((long) position);
         file.write(bytes);
         file.close();
       }
@@ -234,11 +234,11 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void read(String filepath, int length, long position, Promise promise) {
+  public void read(String filepath, int length, double position, Promise promise) {
     try {
       InputStream inputStream = getInputStream(filepath);
       byte[] buffer = new byte[length];
-      inputStream.skip(position);
+      inputStream.skip((long) position);
       int bytesRead = inputStream.read(buffer, 0, length);
 
       String base64Content = Base64.encodeToString(buffer, 0, bytesRead, Base64.NO_WRAP);


### PR DESCRIPTION
There are 2 issues fixed:
1. Large file read offset (the type was incorrect, int->unit64)
2. react-native 0.79.0 types compatibility (it does not support NSInteger for method parameters)

Could not test Android.