### PR TITLE
Fix NullPointerException in PromiseImpl.reject by providing non-null error code [DA-2077]

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -975,7 +975,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       return;
     }
 
-    promise.reject(null, ex.getMessage());
+    promise.reject("EUNSPECIFIED", ex.getMessage());
   }
 
   private void rejectFileNotFound(Promise promise, String filepath) {


### PR DESCRIPTION
PromiseImpl.reject requires a non-null code parameter. The fallback path in reject() was passing null, causing a crash when download errors were neither FileNotFoundException nor IORejectionException.

Related:
 - https://planitar.atlassian.net/browse/DA-2077